### PR TITLE
AI messages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.37.0",
+      "version": "4.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -155,9 +155,9 @@ csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/PillsBot/PillsBot.Server/bin/Debug/netcoreapp3.1/bot.dll",
+            "program": "${workspaceFolder}/src/PillsBot/PillsBot.Server/bin/Debug/net8.0/bot.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/PillsBot/PillsBot.Server",
             "stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ pills-bot  | [17:17:49 INF] Bot started.
 pills-bot  | [17:17:49 INF] Next reminder comes off at 06/18/2023 20:00:00
 ```
 
+## Environment variables
+
+Environment variables are listed below:
+
+|---|---|---|---|
+|Environment variable|Required|Default value|Description|
+|---|---|---|---|
+|PILLSBOT__CONNECTION__APITOKEN|Yes||The API token for your bot in Telegram|
+|PILLSBOT__CONNECTION__CHATID|No||Ignore messages from chats or users other than this one|
+|PILLSBOT__REMINDER__BEGINS|No|Start + 5 sec|The local date and time after which to schedule reminders|
+|PILLSBOT__REMINDER__INTERVAL|No|12 hours|The interval after which a new reminder will be sent|
+|PILLSBOT__REMINDER__MESSAGE|No|Pills time!|The default message to send|
+|PILLSBOT__AI__ENABLED|No|False|Enabled AI features (requires a model in Azure OpenAI)|
+|PILLSBOT__AI__LANGUAGES|No|English|Comma-separated list of languages|
+|PILLSBOT__AI__PETNAMES|No|unknown|The name(s) the cat is called|
+|PILLSBOT__AI__PETGENDER|No|unknown|The gender of the cat (male or female)|
+|PILLSBOT__AI__LOGLEVEL|No|Warning|The minimum log level for Semantic Kernel diagnostics|
+|PILLSBOT__AI__AZURE__ENDPOINT|If AI enabled||The Azure OpenAI endpoint|
+|PILLSBOT__AI__AZURE__KEY|If AI enabled||The Azure OpenAI API key|
+|PILLSBOT__AI__AZURE__DEPLOYMENTNAME|If AI enabled||The Azure OpenAI deployment name|

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ services:
     environment:
       PILLSBOT__CONNECTION__APITOKEN: "" # your Telegram bot's API token
       PILLSBOT__CONNECTION__CHATID: "" # your Telegram group chat ID
-      PILLSBOT__REMINDER__BEGINS: "2022-09-11T10:00:00+02:00" # the begin date and time
+      PILLSBOT__REMINDER__BEGINS: "2022-09-11T10:00:00" # the begin date and time (local)
     restart: unless-stopped
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ pills-bot  | [17:17:49 INF] Next reminder comes off at 06/18/2023 20:00:00
 
 Environment variables are listed below:
 
-|---|---|---|---|
 |Environment variable|Required|Default value|Description|
 |---|---|---|---|
 |PILLSBOT__CONNECTION__APITOKEN|Yes||The API token for your bot in Telegram|

--- a/docker.cake
+++ b/docker.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Docker&version=0.11.0
+#addin nuget:?package=Cake.Docker&version=1.3.0
 
 var target = Argument("target", "Default");
 var tag = Argument("tag", "latest");

--- a/src/PillsBot/PillsBot.Server/AzureOpenAIMessageProvider.cs
+++ b/src/PillsBot/PillsBot.Server/AzureOpenAIMessageProvider.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using PillsBot.Server.Configuration;
+
+namespace PillsBot.Server;
+
+internal sealed class AzureOpenAIMessageProvider : IMessageProvider
+{
+    private readonly IOptions<PillsBotOptions> _options;
+    private readonly ILogger<AzureOpenAIMessageProvider> _logger;
+    private readonly ConfigurationMessageProvider _configurationMessageProvider;
+    private readonly Kernel _kernel;
+
+    public AzureOpenAIMessageProvider(IOptions<PillsBotOptions> options, 
+        ILogger<AzureOpenAIMessageProvider> logger,
+        ConfigurationMessageProvider configurationMessageProvider)
+    {
+        _options = options;
+        _logger = logger;
+        _configurationMessageProvider = configurationMessageProvider;
+
+        string endpoint = options.Value.AI.Azure.Endpoint
+            ?? throw new InvalidOperationException("Azure OpenAI endpoint is not configured.");
+        string key = options.Value.AI.Azure.Key
+            ?? throw new InvalidOperationException("Azure OpenAI key is not configured.");
+        string deploymentName = options.Value.AI.Azure.DeploymentName
+            ?? throw new InvalidOperationException("Azure OpenAI deployment name is not configured.");
+            
+        IKernelBuilder builder = Kernel.CreateBuilder()
+            .AddAzureOpenAIChatCompletion(deploymentName, endpoint, key);
+
+        builder.Services.AddLogging(builder => 
+            builder.AddConsole().SetMinimumLevel(options.Value.AI.LogLevel));
+
+        _kernel = builder.Build();
+    }
+
+    public Task<string> GetMessage(CancellationToken cancellationToken = default)
+    {
+        string systemPrompt = @"
+            You are a friendly assistant who reminds cat owners
+            to give a pill to their cat twice a day.";
+
+        string promptTemplate = @"
+            The cat's names are {{$names}}. You may include a single name in the message, but be sure to address the owners, not the cat.
+            The cat's gender is {{$gender}}. Make sure to consider the gender if the language has different words for the cat depending on the gender.
+
+            Generate a short message reminding the owners that it is now time to give a pill. 
+            The message should be addressed to a human who will be giving the cat a pill.
+
+            The message must end with an exclamation sign.
+
+            Keep the message length at most 3 words.
+            Use either of these languages with uniform probability: {{$languages}}. 
+            ";
+
+        OpenAIPromptExecutionSettings executionSettings = new()
+        {
+            ChatSystemPrompt = systemPrompt,
+            Temperature = 0.7,
+            MaxTokens = 100
+        };
+
+        KernelArguments args = new(executionSettings)
+        {
+            ["languages"] = _options.Value.AI.Languages,
+            ["names"] = _options.Value.AI.PetNames,
+            ["gender"] = _options.Value.AI.PetGender
+        };
+
+        KernelFunction function = _kernel.CreateFunctionFromPrompt(promptTemplate, executionSettings);
+
+        return GetMessageInternal(function, args, cancellationToken);
+    }
+
+    private async Task<string> GetMessageInternal(KernelFunction function, KernelArguments arguments, 
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            FunctionResult result = await _kernel.InvokeAsync(function, arguments, cancellationToken);
+            return result.ToString();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Error invoking the prompt. Defaulting to the message in configuration.");
+            return await _configurationMessageProvider.GetMessage(cancellationToken);
+        }
+    }
+}

--- a/src/PillsBot/PillsBot.Server/BotService.cs
+++ b/src/PillsBot/PillsBot.Server/BotService.cs
@@ -8,12 +8,14 @@ using PillsBot.Server.Configuration;
 
 namespace PillsBot.Server
 {
-    internal class BotService(ILogger<BotService> logger, IMessenger messenger, 
-        IOptions<PillsBotOptions> options) : BackgroundService
+    internal class BotService(ILogger<BotService> logger, IMessenger messenger,
+        IOptions<PillsBotOptions> options, IMessageProvider messageProvider)
+        : BackgroundService
     {
         private readonly ILogger<BotService> _logger = logger;
         private readonly IMessenger _messenger = messenger;
         private readonly PillsBotOptions _options = options.Value;
+        private readonly IMessageProvider _messageProvider = messageProvider;
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
@@ -33,7 +35,7 @@ namespace PillsBot.Server
 
             DateTime begins = _options.Reminder.Begins;
             TimeSpan interval = _options.Reminder.Interval;
-            string message = _options.Reminder.Message;
+            string message = await _messageProvider.GetMessage(stoppingToken);
 
             DateTime next = GetNext(begins, interval);
             _logger.LogInformation("Next reminder comes off at {Next}", next);

--- a/src/PillsBot/PillsBot.Server/Configuration/PillsBotOptions.cs
+++ b/src/PillsBot/PillsBot.Server/Configuration/PillsBotOptions.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
 
 namespace PillsBot.Server.Configuration
 {
     public class PillsBotOptions
     {
         public ConnectionOptions Connection { get; set; }
-        public ReminderOptions Reminder { get; set; } = new ReminderOptions();
+        public ReminderOptions Reminder { get; set; } = new();
+        public AIOptions AI { get; set; } = new();
     }
 
     public class ConnectionOptions
@@ -16,8 +18,25 @@ namespace PillsBot.Server.Configuration
 
     public class ReminderOptions
     {
-        public DateTime Begins { get; set; } = new DateTime(2020, 1, 1, 8, 00, 00, DateTimeKind.Utc);
+        public DateTime Begins { get; set; } = DateTime.Now.AddSeconds(5);
         public TimeSpan Interval { get; set; } = TimeSpan.FromDays(.5);
         public string Message { get; set; } = "Pills time!";
+    }
+
+    public class AIOptions
+    {
+        public bool Enabled { get; set; } = false;
+        public string Languages { get; set; } = "English";
+        public string PetNames { get; set; } = "unknown";
+        public string PetGender { get; set; } = "unknown";
+        public LogLevel LogLevel { get; set; } = LogLevel.Warning;
+        public AzureOpenAIOptions Azure { get; set; } = new();
+
+        public class AzureOpenAIOptions
+        {
+            public string Endpoint { get; set; }
+            public string Key { get; set; }
+            public string DeploymentName { get; set; }
+        }
     }
 }

--- a/src/PillsBot/PillsBot.Server/Configuration/ServiceCollectionExtensions.cs
+++ b/src/PillsBot/PillsBot.Server/Configuration/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace PillsBot.Server.Configuration
 {
@@ -15,6 +16,14 @@ namespace PillsBot.Server.Configuration
                 .AddTransient<ITelegramClientFactory, TelegramClientFactory>()
                 .AddTransient<IMessenger, TelegramMessenger>()
                 .AddHostedService<BotService>();
+            
+            services
+                .AddTransient<AzureOpenAIMessageProvider>()
+                .AddTransient<ConfigurationMessageProvider>()
+                .AddTransient<IMessageProvider>(provider => provider
+                    .GetRequiredService<IOptions<PillsBotOptions>>().Value.AI.Enabled
+                        ? provider.GetRequiredService<AzureOpenAIMessageProvider>()
+                        : provider.GetRequiredService<ConfigurationMessageProvider>());
 
             return services;
         }

--- a/src/PillsBot/PillsBot.Server/ConfigurationMessageProvider.cs
+++ b/src/PillsBot/PillsBot.Server/ConfigurationMessageProvider.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using PillsBot.Server.Configuration;
+
+namespace PillsBot.Server;
+
+internal sealed class ConfigurationMessageProvider(IOptions<PillsBotOptions> options) : IMessageProvider
+{
+    private readonly IOptions<PillsBotOptions> _options = options;
+
+    public Task<string> GetMessage(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_options.Value.Reminder.Message);
+    }
+}

--- a/src/PillsBot/PillsBot.Server/EventIds.cs
+++ b/src/PillsBot/PillsBot.Server/EventIds.cs
@@ -4,8 +4,8 @@ namespace PillsBot.Server
 {
     public static class EventIds
     {
-        public static readonly EventId TelegramClientCreationFailed = new EventId(1, nameof(TelegramClientCreationFailed));
-        internal static readonly EventId BotStartupFailed = new EventId(2, nameof(BotStartupFailed));
-        internal static readonly EventId BotShutdownFailed = new EventId(3, nameof(BotShutdownFailed));
+        public static readonly EventId TelegramClientCreationFailed = new(1, nameof(TelegramClientCreationFailed));
+        internal static readonly EventId BotStartupFailed = new(2, nameof(BotStartupFailed));
+        internal static readonly EventId BotShutdownFailed = new(3, nameof(BotShutdownFailed));
     }
 }

--- a/src/PillsBot/PillsBot.Server/Interfaces/IMessageProvider.cs
+++ b/src/PillsBot/PillsBot.Server/Interfaces/IMessageProvider.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PillsBot.Server;
+
+internal interface IMessageProvider
+{
+    internal Task<string> GetMessage(CancellationToken cancellationToken = default);
+}

--- a/src/PillsBot/PillsBot.Server/Interfaces/IMessenger.cs
+++ b/src/PillsBot/PillsBot.Server/Interfaces/IMessenger.cs
@@ -6,7 +6,6 @@ namespace PillsBot.Server
     internal interface IMessenger
     {
         Task Start(CancellationToken cancellationToken = default);
-        Task Stop(CancellationToken cancellationToken = default);
         Task Notify(string message, CancellationToken cancellationToken = default);
     }
 }

--- a/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
+++ b/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>PillsBot.Server</RootNamespace>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <AssemblyName>bot</AssemblyName>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.30.0.95878">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Telegram.Bot" Version="15.7.1" />
+    <PackageReference Include="Telegram.Bot" Version="19.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
+++ b/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.16.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="9.30.0.95878">

--- a/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
+++ b/src/PillsBot/PillsBot.Server/PillsBot.Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>PillsBot.Server</RootNamespace>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
     <AssemblyName>bot</AssemblyName>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/PillsBot/PillsBot.Server/TelegramClientFactory.cs
+++ b/src/PillsBot/PillsBot.Server/TelegramClientFactory.cs
@@ -6,14 +6,9 @@ using Telegram.Bot;
 
 namespace PillsBot.Server
 {
-    public class TelegramClientFactory : ITelegramClientFactory
+    public class TelegramClientFactory(ILogger<TelegramClientFactory> logger) : ITelegramClientFactory
     {
-        private readonly ILogger<TelegramClientFactory> _logger;
-
-        public TelegramClientFactory(ILogger<TelegramClientFactory> logger)
-        {
-            _logger = logger;
-        }
+        private readonly ILogger<TelegramClientFactory> _logger = logger;
 
         public async Task<ITelegramBotClient> Create(string token, CancellationToken cancellationToken = default)
         {

--- a/src/PillsBot/PillsBot.Server/TelegramMessenger.cs
+++ b/src/PillsBot/PillsBot.Server/TelegramMessenger.cs
@@ -77,7 +77,7 @@ namespace PillsBot.Server
 
         private async Task OnCallbackQuery(CallbackQuery query, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("A callback query received: {@CallbackQuery}", query);
+            _logger.LogTrace("A callback query received: {@CallbackQuery}", query);
 
             long chatId = query.Message.Chat.Id;
             if (chatId != _options.Connection.ChatId)

--- a/src/PillsBot/PillsBot.Server/TelegramMessenger.cs
+++ b/src/PillsBot/PillsBot.Server/TelegramMessenger.cs
@@ -1,63 +1,46 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PillsBot.Server.Configuration;
 using Telegram.Bot;
-using Telegram.Bot.Args;
+using Telegram.Bot.Polling;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace PillsBot.Server
 {
-    internal class TelegramMessenger : IMessenger
+    internal class TelegramMessenger(ILogger<TelegramMessenger> logger,
+        ITelegramClientFactory clientFactory, IOptions<PillsBotOptions> options)
+        : IMessenger, IUpdateHandler
     {
-        private static readonly UpdateType[] AllowedUpdates = { UpdateType.Message, UpdateType.CallbackQuery };
-
-        private readonly ILogger<TelegramMessenger> _logger;
-        private readonly PillsBotOptions _options;
-        private readonly ITelegramClientFactory _clientFactory;
-        private ITelegramBotClient _client;
-        private CancellationToken _cancellationToken;
-
-        public TelegramMessenger(ILogger<TelegramMessenger> logger, ITelegramClientFactory clientFactory, IOptions<PillsBotOptions> options)
+        private static readonly ReceiverOptions ReceiverOptions = new()
         {
-            _logger = logger;
-            _options = options.Value;
-            _clientFactory = clientFactory;
-        }
+            AllowedUpdates = [UpdateType.Message, UpdateType.CallbackQuery]
+        };
+
+        private readonly ILogger<TelegramMessenger> _logger = logger;
+        private readonly PillsBotOptions _options = options.Value;
+        private readonly ITelegramClientFactory _clientFactory = clientFactory;
+        private ITelegramBotClient _client;
 
         public async Task Start(CancellationToken cancellationToken = default)
         {
-            _client = await _clientFactory.Create(_options.Connection.ApiToken);
+            _client = await _clientFactory.Create(_options.Connection.ApiToken, cancellationToken);
 
             // webhooks not supported
             WebhookInfo webhookInfo = await _client.GetWebhookInfoAsync(cancellationToken);
             if (!string.IsNullOrEmpty(webhookInfo.Url))
             {
                 _logger.LogWarning("A webhook is set up on the server. Deleting...");
-                await _client.DeleteWebhookAsync(cancellationToken);
+                await _client.DeleteWebhookAsync(true, cancellationToken);
             }
 
-            _client.OnMessage += OnClientMessage;
-            _client.OnCallbackQuery += OnCallbackQuery;
-            _client.StartReceiving(AllowedUpdates, cancellationToken);
+            _client.StartReceiving(this, ReceiverOptions, cancellationToken);
             _logger.LogInformation("Started receiving updates.");
-
-            _cancellationToken = cancellationToken;
-        }
-
-        public Task Stop(CancellationToken cancellationToken = default)
-        {
-            _client.StopReceiving();
-            _client.OnMessage -= OnClientMessage;
-            _client.OnCallbackQuery -= OnCallbackQuery;
-
-            _logger.LogInformation("Stopped receiving updates");
-
-            return Task.CompletedTask;
         }
 
         public async Task Notify(string message, CancellationToken cancellationToken = default)
@@ -68,45 +51,58 @@ namespace PillsBot.Server
             IReplyMarkup replyMarkup = GetReplyMarkup();
 
             _logger.LogInformation("Sending message: {Message} to chat {ChatId}", message, chatId);
-            await _client.SendTextMessageAsync(chatId, message, ParseMode.Default,
-                cancellationToken: cancellationToken, replyMarkup: replyMarkup);
+            await _client.SendTextMessageAsync(chatId, message, replyMarkup: replyMarkup,
+                cancellationToken: cancellationToken);
 
             _logger.LogInformation("Message sent.");
         }
 
-        private void OnCallbackQuery(object sender, CallbackQueryEventArgs e)
+        public Task HandleUpdateAsync(ITelegramBotClient botClient, Update update,
+            CancellationToken cancellationToken)
         {
-            _logger.LogInformation("A callback query received: {@CallbackQuery}", e.CallbackQuery);
+            return update.Type switch
+            {
+                UpdateType.CallbackQuery => OnCallbackQuery(update.CallbackQuery, cancellationToken),
+                UpdateType.Message => OnClientMessage(update.Message),
+                _ => throw new InvalidEnumArgumentException("UpdateType", (int)update.Type, typeof(UpdateType))
+            };
+        }
 
-            var chatId = e.CallbackQuery.Message.Chat.Id;
+        public Task HandlePollingErrorAsync(ITelegramBotClient botClient, Exception exception,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogError(exception, "Polling error.");
+            return Task.CompletedTask;
+        }
+
+        private async Task OnCallbackQuery(CallbackQuery query, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("A callback query received: {@CallbackQuery}", query);
+
+            long chatId = query.Message.Chat.Id;
             if (chatId != _options.Connection.ChatId)
             {
-                _logger.LogWarning("Unexpected chat id in callback query: {@CallbackQuery}", e.CallbackQuery);
+                _logger.LogWarning("Unexpected chat id in callback query: {@CallbackQuery}", query);
                 return;
             }
 
             // fire message removal
-            _client.DeleteMessageAsync(chatId, e.CallbackQuery.Message.MessageId, _cancellationToken);
+            await _client.DeleteMessageAsync(chatId, query.Message.MessageId, cancellationToken);
 
             // fire callback
-            _client.AnswerCallbackQueryAsync(e.CallbackQuery.Id, "🐱", cancellationToken: _cancellationToken);
+            await _client.AnswerCallbackQueryAsync(query.Id, "🐱", cancellationToken: cancellationToken);
         }
 
-        private void OnClientMessage(object sender, MessageEventArgs e)
+        private Task OnClientMessage(Message message)
         {
-            _logger.LogInformation("A message received: {@Message}", e.Message);
+            _logger.LogInformation("A message received: {@Message}", message);
+            return Task.CompletedTask;
         }
 
-        private IReplyMarkup GetReplyMarkup()
+        private static InlineKeyboardMarkup GetReplyMarkup()
         {
-            var inlineKeyboardButton = new InlineKeyboardButton
-            {
-                CallbackData = "roger",
-                Text = "Eaten!"
-            };
-
+            var inlineKeyboardButton = InlineKeyboardButton.WithCallbackData("Eaten!", "roger");
             var result = new InlineKeyboardMarkup(inlineKeyboardButton);
-
             return result;
         }
     }

--- a/src/docker/amd64/Dockerfile
+++ b/src/docker/amd64/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet publish "PillsBot/PillsBot.Server/PillsBot.Server.csproj" \


### PR DESCRIPTION
- Now generates a new message using Azure OpenAI (tested with `gpt-4o`)
- Updated start time for the reminder to be local (due to [this breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/dmtf-todatetime))
- Upgraded to .NET 8 and Cake 4. 
- Fixed building for ARM64.